### PR TITLE
deps: add support for AvalancheGo v1.9.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ See [`bin/timestampvm`](timestampvm/src/bin/timestampvm/main.rs) for plugin impl
 | --- | --- |
 | v0.0.6 | v1.9.2,v1.9.3 |
 | v0.0.7 | v1.9.4 |
+| v0.0.8 | v1.9.7 |
 
 ## Example
 

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -27,7 +27,7 @@ echo VM_PLUGIN_PATH: ${VM_PLUGIN_PATH}
 # https://github.com/ava-labs/avalanche-network-runner
 # TODO: use "go install -v github.com/ava-labs/avalanche-network-runner/cmd/avalanche-network-runner@v${NETWORK_RUNNER_VERSION}"
 GOOS=$(go env GOOS)
-NETWORK_RUNNER_VERSION=1.3.0
+NETWORK_RUNNER_VERSION=1.3.5
 DOWNLOAD_PATH=/tmp/avalanche-network-runner.tar.gz
 DOWNLOAD_URL=https://github.com/ava-labs/avalanche-network-runner/releases/download/v${NETWORK_RUNNER_VERSION}/avalanche-network-runner_${NETWORK_RUNNER_VERSION}_linux_amd64.tar.gz
 if [[ ${GOOS} == "darwin" ]]; then

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://avax.network"
 [dev-dependencies]
 avalanche-installer = "0.0.12"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.176", features = ["client", "subnet"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.228", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
 env_logger = "0.10.0"
 log = "0.4.17"
 random-manager = "0.0.2"

--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -9,10 +9,7 @@ pub fn get_network_runner_grpc_endpoint() -> (String, bool) {
 }
 
 pub fn get_network_runner_enable_shutdown() -> bool {
-    match std::env::var("NETWORK_RUNNER_ENABLE_SHUTDOWN") {
-        Ok(_) => true,
-        _ => false,
-    }
+    matches!(std::env::var("NETWORK_RUNNER_ENABLE_SHUTDOWN"), Ok(_))
 }
 
 pub fn get_avalanchego_path() -> (String, bool) {

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -7,9 +7,9 @@ use std::{
 };
 
 use avalanche_network_runner_sdk::{BlockchainSpec, Client, GlobalConfig, StartRequest};
-use avalanche_types::{client::info as avalanche_sdk_info, ids, subnet};
+use avalanche_types::{ids, jsonrpc::client::info as avalanche_sdk_info, subnet};
 
-const AVALANCHEGO_VERSION: &str = "v1.9.4";
+const AVALANCHEGO_VERSION: &str = "v1.9.7";
 
 #[tokio::test]
 async fn e2e() {
@@ -69,6 +69,8 @@ async fn e2e() {
         plugins_dir,
         vm_id
     );
+
+    fs::create_dir(&plugins_dir).unwrap();
     fs::copy(
         &vm_plugin_path,
         Path::new(&plugins_dir).join(&vm_id.to_string()),

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timestampvm"
-version = "0.0.7" # https://crates.io/crates/timestampvm
+version = "0.0.8" # https://crates.io/crates/timestampvm
 edition = "2021"
 rust-version = "1.65"
 publish = true
@@ -11,13 +11,13 @@ repository = "https://github.com/ava-labs/timestampvm-rs"
 readme = "../README.md"
 
 [dependencies]
-avalanche-types = { version = "0.0.176", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
-base64 = { version = "0.20.0" }
+avalanche-types = { version = "0.0.228", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
+base64 = { version = "0.21.0" }
 chrono = "0.4.23"
 clap = { version = "4.0.29", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 derivative = "2.2.0"
 env_logger = "0.10.0"
-http-manager = { version = "0.0.6" }
+http-manager = { version = "0.0.8" }
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = { version = "18.0.0" }
 jsonrpc-derive = "18.0.0"

--- a/timestampvm/src/client/mod.rs
+++ b/timestampvm/src/client/mod.rs
@@ -129,7 +129,10 @@ pub async fn propose_block(
     data.method = String::from("timestampvm.proposeBlock");
 
     let mut m = HashMap::new();
-    m.insert("data".to_string(), base64::encode(&d));
+    m.insert(
+        "data".to_string(),
+        base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &d),
+    );
 
     let params = vec![m];
     data.params = Some(params);

--- a/timestampvm/src/state/mod.rs
+++ b/timestampvm/src/state/mod.rs
@@ -107,7 +107,7 @@ impl State {
         match db.get(LAST_ACCEPTED_BLOCK_KEY).await {
             Ok(d) => Ok(ids::Id::from_slice(&d)),
             Err(e) => {
-                if subnet::rpc::database::errors::is_not_found(&e) {
+                if subnet::rpc::errors::is_not_found(&e) {
                     return Ok(ids::Id::empty());
                 }
                 Err(e)


### PR DESCRIPTION
This PR bumps deps and adds support for protocol version 22 and AvalancheGo@1.9.7.