### PR TITLE
github/workflows: use ubuntu-20.04 for building release binaries

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -151,7 +151,7 @@ jobs:
       matrix:
         job:
           # https://doc.rust-lang.org/nightly/rustc/platform-support.html
-          - os: ubuntu-latest
+          - os: ubuntu-20.04
             platform: linux
             target: x86_64-unknown-linux-gnu
           - os: macos-latest


### PR DESCRIPTION
ubuntu latest breaks release binaries which are missing GLIBC 2 dep.

```

 ./timestampvm 
./timestampvm: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by ./timestampvm)
./timestampvm: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.33' not found (required by ./timestampvm)
./timestampvm: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by ./timestampvm
```



Signed-off-by: Sam Batschelet <sam.batschelet@avalabs.org>