### PR TITLE
fix: Run clippy lints and add default VM trait

### DIFF
--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -73,7 +73,7 @@ async fn e2e() {
     fs::create_dir(&plugins_dir).unwrap();
     fs::copy(
         &vm_plugin_path,
-        Path::new(&plugins_dir).join(&vm_id.to_string()),
+        Path::new(&plugins_dir).join(vm_id.to_string()),
     )
     .unwrap();
 
@@ -170,7 +170,7 @@ async fn e2e() {
         }
 
         if let Some(ci) = &status.cluster_info {
-            if ci.custom_chains.len() > 0 {
+            if !ci.custom_chains.is_empty() {
                 break;
             }
         }

--- a/timestampvm/src/block/mod.rs
+++ b/timestampvm/src/block/mod.rs
@@ -409,7 +409,7 @@ impl subnet::rpc::consensus::snowman::Block for Block {
     }
 
     async fn parent(&self) -> ids::Id {
-        self.parent_id.clone()
+        self.parent_id
     }
 
     async fn verify(&mut self) -> io::Result<()> {

--- a/timestampvm/src/genesis/mod.rs
+++ b/timestampvm/src/genesis/mod.rs
@@ -61,7 +61,7 @@ impl Genesis {
             )
         })?;
 
-        let mut f = File::create(&file_path)?;
+        let mut f = File::create(file_path)?;
         f.write_all(&d)?;
 
         Ok(())

--- a/timestampvm/src/state/mod.rs
+++ b/timestampvm/src/state/mod.rs
@@ -165,7 +165,7 @@ impl State {
         let db = self.db.read().await;
 
         let blk_status_bytes = db.get(&block_with_status_key(blk_id)).await?;
-        let blk_status = BlockWithStatus::from_slice(&blk_status_bytes)?;
+        let blk_status = BlockWithStatus::from_slice(blk_status_bytes)?;
 
         let mut blk = Block::from_slice(&blk_status.block_bytes)?;
         blk.set_status(blk_status.status);

--- a/timestampvm/src/vm/mod.rs
+++ b/timestampvm/src/vm/mod.rs
@@ -66,6 +66,12 @@ pub struct Vm {
     pub mempool: Arc<RwLock<VecDeque<Vec<u8>>>>,
 }
 
+impl Default for Vm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Vm {
     pub fn new() -> Self {
         Self {


### PR DESCRIPTION
Some small QoL improvements for the codebase.

Signed-off-by: Dan Sover <dan.sover@avalabs.org>
