### PR TITLE
0.0.11: Add support for protocol version 24

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ See [`bin/timestampvm`](timestampvm/src/bin/timestampvm/main.rs) for plugin impl
 | v0.0.7  | v1.9.4 |
 | v0.0.8, v0.0.9  | v1.9.7 |
 | v0.0.10 | v1.9.8, v1.9.9 |
+| v0.0.11 | v1.9.10, v1.9.11 |
 
 ## Example
 

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -27,7 +27,7 @@ echo VM_PLUGIN_PATH: ${VM_PLUGIN_PATH}
 # https://github.com/ava-labs/avalanche-network-runner
 # TODO: use "go install -v github.com/ava-labs/avalanche-network-runner/cmd/avalanche-network-runner@v${NETWORK_RUNNER_VERSION}"
 GOOS=$(go env GOOS)
-NETWORK_RUNNER_VERSION=1.3.5
+NETWORK_RUNNER_VERSION=1.3.9
 DOWNLOAD_PATH=/tmp/avalanche-network-runner.tar.gz
 DOWNLOAD_URL=https://github.com/ava-labs/avalanche-network-runner/releases/download/v${NETWORK_RUNNER_VERSION}/avalanche-network-runner_${NETWORK_RUNNER_VERSION}_linux_amd64.tar.gz
 if [[ ${GOOS} == "darwin" ]]; then

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -2,7 +2,7 @@
 name = "e2e"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.68"
 publish = false
 description = "Byzantine tests for Avalanche Go"
 license = "BSD-3-Clause"
@@ -11,13 +11,13 @@ homepage = "https://avax.network"
 [dependencies]
 
 [dev-dependencies]
-avalanche-installer = "0.0.49"
+avalanche-installer = "0.0.50"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.312", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.313", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
 env_logger = "0.10.0"
 log = "0.4.17"
 random-manager = "0.0.5"
-serde_json = "1.0.93" # https://github.com/serde-rs/json/releases
+serde_json = "1.0.94" # https://github.com/serde-rs/json/releases
 tempfile = "3.4.0"
 timestampvm = { path = "../../timestampvm" }
 tokio = { version = "1.25.0", features = [] } # https://github.com/tokio-rs/tokio/releases

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -11,9 +11,9 @@ homepage = "https://avax.network"
 [dependencies]
 
 [dev-dependencies]
-avalanche-installer = "0.0.41"
+avalanche-installer = "0.0.49"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.272", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.312", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
 env_logger = "0.10.0"
 log = "0.4.17"
 random-manager = "0.0.5"

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -13,7 +13,7 @@ homepage = "https://avax.network"
 [dev-dependencies]
 avalanche-installer = "0.0.50"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.313", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.319", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
 env_logger = "0.10.0"
 log = "0.4.17"
 random-manager = "0.0.5"

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use avalanche_network_runner_sdk::{BlockchainSpec, Client, GlobalConfig, StartRequest};
 use avalanche_types::{ids, jsonrpc::client::info as avalanche_sdk_info, subnet};
 
-const AVALANCHEGO_VERSION: &str = "v1.9.9";
+const AVALANCHEGO_VERSION: &str = "v1.9.11";
 
 #[tokio::test]
 async fn e2e() {

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timestampvm"
-version = "0.0.10" # https://crates.io/crates/timestampvm
+version = "0.0.11" # https://crates.io/crates/timestampvm
 edition = "2021"
 rust-version = "1.68"
 publish = true

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -2,7 +2,7 @@
 name = "timestampvm"
 version = "0.0.10" # https://crates.io/crates/timestampvm
 edition = "2021"
-rust-version = "1.65"
+rust-version = "1.68"
 publish = true
 description = "Timestamp VM in Rust"
 documentation = "https://docs.rs/timestampvm"
@@ -11,7 +11,7 @@ repository = "https://github.com/ava-labs/timestampvm-rs"
 readme = "../README.md"
 
 [dependencies]
-avalanche-types = { version = "0.0.312", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.313", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
 base64 = { version = "0.21.0" }
 chrono = "0.4.23"
 clap = { version = "4.1.8", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ava-labs/timestampvm-rs"
 readme = "../README.md"
 
 [dependencies]
-avalanche-types = { version = "0.0.313", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.319", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
 base64 = { version = "0.21.0" }
 chrono = "0.4.23"
 clap = { version = "4.1.8", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ava-labs/timestampvm-rs"
 readme = "../README.md"
 
 [dependencies]
-avalanche-types = { version = "0.0.272", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.312", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
 base64 = { version = "0.21.0" }
 chrono = "0.4.23"
 clap = { version = "4.1.8", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases

--- a/timestampvm/src/api/chain_handlers.rs
+++ b/timestampvm/src/api/chain_handlers.rs
@@ -3,8 +3,8 @@
 
 use std::str::FromStr;
 
-use crate::{block::Block, vm};
-use avalanche_types::{ids, subnet::rpc::snow::engine::common::appsender::AppSender};
+use crate::{block::Block, vm::Vm};
+use avalanche_types::ids;
 use jsonrpc_core::{BoxFuture, Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
@@ -62,23 +62,23 @@ pub struct GetBlockResponse {
 /// Implements API services for the chain-specific handlers.
 pub struct Service<A>
 where
-    A: AppSender + Send + Sync + Clone + 'static,
+    A: Send + Sync + Clone + 'static,
 {
-    pub vm: vm::Vm<A>,
+    pub vm: Vm<A>,
 }
 
 impl<A> Service<A>
 where
-    A: AppSender + Send + Sync + Clone + 'static,
+    A: Send + Sync + Clone + 'static,
 {
-    pub fn new(vm: vm::Vm<A>) -> Self {
+    pub fn new(vm: Vm<A>) -> Self {
         Self { vm }
     }
 }
 
 impl<A> Rpc for Service<A>
 where
-    A: AppSender + Send + Sync + Clone + 'static,
+    A: Send + Sync + Clone + 'static,
 {
     fn ping(&self) -> BoxFuture<Result<crate::api::PingResponse>> {
         log::debug!("ping called");

--- a/timestampvm/src/api/chain_handlers.rs
+++ b/timestampvm/src/api/chain_handlers.rs
@@ -4,7 +4,7 @@
 use std::str::FromStr;
 
 use crate::{block::Block, vm};
-use avalanche_types::ids;
+use avalanche_types::{ids, subnet::rpc::snow::engine::common::appsender::AppSender};
 use jsonrpc_core::{BoxFuture, Error, ErrorCode, Result};
 use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
@@ -60,17 +60,26 @@ pub struct GetBlockResponse {
 }
 
 /// Implements API services for the chain-specific handlers.
-pub struct Service {
-    pub vm: vm::Vm,
+pub struct Service<A>
+where
+    A: AppSender + Send + Sync + Clone + 'static,
+{
+    pub vm: vm::Vm<A>,
 }
 
-impl Service {
-    pub fn new(vm: vm::Vm) -> Self {
+impl<A> Service<A>
+where
+   A: AppSender + Send + Sync + Clone + 'static,
+{
+    pub fn new(vm: vm::Vm<A>) -> Self {
         Self { vm }
     }
 }
 
-impl Rpc for Service {
+impl<A> Rpc for Service<A>
+where
+    A: AppSender + Send + Sync + Clone + 'static,
+{
     fn ping(&self) -> BoxFuture<Result<crate::api::PingResponse>> {
         log::debug!("ping called");
         Box::pin(async move { Ok(crate::api::PingResponse { success: true }) })

--- a/timestampvm/src/api/chain_handlers.rs
+++ b/timestampvm/src/api/chain_handlers.rs
@@ -60,10 +60,7 @@ pub struct GetBlockResponse {
 }
 
 /// Implements API services for the chain-specific handlers.
-pub struct Service<A>
-where
-    A: Send + Sync + Clone + 'static,
-{
+pub struct Service<A> {
     pub vm: Vm<A>,
 }
 

--- a/timestampvm/src/api/chain_handlers.rs
+++ b/timestampvm/src/api/chain_handlers.rs
@@ -64,10 +64,7 @@ pub struct Service<A> {
     pub vm: Vm<A>,
 }
 
-impl<A> Service<A>
-where
-    A: Send + Sync + Clone + 'static,
-{
+impl<A> Service<A> {
     pub fn new(vm: Vm<A>) -> Self {
         Self { vm }
     }

--- a/timestampvm/src/api/chain_handlers.rs
+++ b/timestampvm/src/api/chain_handlers.rs
@@ -69,7 +69,7 @@ where
 
 impl<A> Service<A>
 where
-   A: AppSender + Send + Sync + Clone + 'static,
+    A: AppSender + Send + Sync + Clone + 'static,
 {
     pub fn new(vm: vm::Vm<A>) -> Self {
         Self { vm }

--- a/timestampvm/src/api/static_handlers.rs
+++ b/timestampvm/src/api/static_handlers.rs
@@ -13,10 +13,7 @@ pub trait Rpc {
 }
 
 /// Implements API services for the static handlers.
-pub struct Service<A>
-where
-    A: Send + Sync + Clone + 'static,
-{
+pub struct Service<A> {
     pub vm: Vm<A>,
 }
 

--- a/timestampvm/src/api/static_handlers.rs
+++ b/timestampvm/src/api/static_handlers.rs
@@ -2,6 +2,7 @@
 //! To be served via `[HOST]/ext/vm/[VM ID]/static`.
 
 use crate::vm;
+use avalanche_types::subnet::rpc::snow::engine::common::appsender::AppSender;
 use jsonrpc_core::{BoxFuture, Result};
 use jsonrpc_derive::rpc;
 
@@ -13,17 +14,26 @@ pub trait Rpc {
 }
 
 /// Implements API services for the static handlers.
-pub struct Service {
-    pub vm: vm::Vm,
+pub struct Service<A>
+where
+    A: AppSender + Send + Sync + Clone + 'static,
+{
+    pub vm: vm::Vm<A>,
 }
 
-impl Service {
-    pub fn new(vm: vm::Vm) -> Self {
+impl<A> Service<A>
+where
+    A: AppSender + Send + Sync + Clone + 'static,
+{
+    pub fn new(vm: vm::Vm<A>) -> Self {
         Self { vm }
     }
 }
 
-impl Rpc for Service {
+impl<A> Rpc for Service<A>
+where
+   A: AppSender + Send + Sync + Clone + 'static,
+{
     fn ping(&self) -> BoxFuture<Result<crate::api::PingResponse>> {
         log::debug!("ping called");
         Box::pin(async move { Ok(crate::api::PingResponse { success: true }) })

--- a/timestampvm/src/api/static_handlers.rs
+++ b/timestampvm/src/api/static_handlers.rs
@@ -1,8 +1,7 @@
 //! Implements static handlers specific to this VM.
 //! To be served via `[HOST]/ext/vm/[VM ID]/static`.
 
-use crate::vm;
-use avalanche_types::subnet::rpc::snow::engine::common::appsender::AppSender;
+use crate::vm::Vm;
 use jsonrpc_core::{BoxFuture, Result};
 use jsonrpc_derive::rpc;
 
@@ -16,23 +15,23 @@ pub trait Rpc {
 /// Implements API services for the static handlers.
 pub struct Service<A>
 where
-    A: AppSender + Send + Sync + Clone + 'static,
+    A: Send + Sync + Clone + 'static,
 {
-    pub vm: vm::Vm<A>,
+    pub vm: Vm<A>,
 }
 
 impl<A> Service<A>
 where
-    A: AppSender + Send + Sync + Clone + 'static,
+    A: Send + Sync + Clone + 'static,
 {
-    pub fn new(vm: vm::Vm<A>) -> Self {
+    pub fn new(vm: Vm<A>) -> Self {
         Self { vm }
     }
 }
 
 impl<A> Rpc for Service<A>
 where
-    A: AppSender + Send + Sync + Clone + 'static,
+    A: Send + Sync + Clone + 'static,
 {
     fn ping(&self) -> BoxFuture<Result<crate::api::PingResponse>> {
         log::debug!("ping called");

--- a/timestampvm/src/api/static_handlers.rs
+++ b/timestampvm/src/api/static_handlers.rs
@@ -32,7 +32,7 @@ where
 
 impl<A> Rpc for Service<A>
 where
-   A: AppSender + Send + Sync + Clone + 'static,
+    A: AppSender + Send + Sync + Clone + 'static,
 {
     fn ping(&self) -> BoxFuture<Result<crate::api::PingResponse>> {
         log::debug!("ping called");

--- a/timestampvm/src/api/static_handlers.rs
+++ b/timestampvm/src/api/static_handlers.rs
@@ -17,10 +17,7 @@ pub struct Service<A> {
     pub vm: Vm<A>,
 }
 
-impl<A> Service<A>
-where
-    A: Send + Sync + Clone + 'static,
-{
+impl<A> Service<A> {
     pub fn new(vm: Vm<A>) -> Self {
         Self { vm }
     }

--- a/timestampvm/src/block/mod.rs
+++ b/timestampvm/src/block/mod.rs
@@ -6,7 +6,12 @@ use std::{
 };
 
 use crate::state;
-use avalanche_types::{choices, codec::serde::hex_0x_bytes::Hex0xBytes, ids, subnet};
+use avalanche_types::{
+    choices,
+    codec::serde::hex_0x_bytes::Hex0xBytes,
+    ids,
+    subnet::rpc::consensus::snowman::{self, Decidable},
+};
 use chrono::{Duration, Utc};
 use derivative::{self, Derivative};
 use serde::{Deserialize, Serialize};
@@ -391,13 +396,9 @@ async fn test_block() {
 }
 
 #[tonic::async_trait]
-impl subnet::rpc::consensus::snowman::Block for Block {
+impl snowman::Block for Block {
     async fn bytes(&self) -> &[u8] {
         return self.bytes.as_ref();
-    }
-
-    async fn to_bytes(&self) -> io::Result<Vec<u8>> {
-        self.to_slice()
     }
 
     async fn height(&self) -> u64 {
@@ -418,7 +419,7 @@ impl subnet::rpc::consensus::snowman::Block for Block {
 }
 
 #[tonic::async_trait]
-impl subnet::rpc::consensus::snowman::Decidable for Block {
+impl Decidable for Block {
     /// Implements "snowman.Block.choices.Decidable"
     async fn status(&self) -> choices::status::Status {
         self.status.clone()
@@ -434,22 +435,5 @@ impl subnet::rpc::consensus::snowman::Decidable for Block {
 
     async fn reject(&mut self) -> io::Result<()> {
         self.reject().await
-    }
-}
-
-#[tonic::async_trait]
-impl subnet::rpc::consensus::snowman::Initializer for Block {
-    async fn init(&mut self, bytes: &[u8], status: choices::status::Status) -> io::Result<()> {
-        *self = Block::from_slice(bytes)?;
-        self.status = status;
-
-        Ok(())
-    }
-}
-
-#[tonic::async_trait]
-impl subnet::rpc::consensus::snowman::StatusWriter for Block {
-    async fn set_status(&mut self, status: choices::status::Status) {
-        self.set_status(status)
     }
 }

--- a/timestampvm/src/vm/mod.rs
+++ b/timestampvm/src/vm/mod.rs
@@ -66,7 +66,7 @@ impl Default for VmState {
 #[derive(Clone)]
 pub struct Vm<A>
 where
-  A: AppSender + Send + Sync + Clone + 'static,
+    A: AppSender + Send + Sync + Clone + 'static,
 {
     /// Maintains the Vm-specific states.
     pub state: Arc<RwLock<VmState>>,
@@ -79,7 +79,7 @@ where
 
 impl<A> Default for Vm<A>
 where
-A: AppSender + Send + Sync + Clone + 'static,
+    A: AppSender + Send + Sync + Clone + 'static,
 {
     fn default() -> Self {
         Self::new()
@@ -194,16 +194,12 @@ where
     }
 }
 
-impl<A> subnet::rpc::vm::Vm for Vm<A>
-where
-A: AppSender + Send + Sync + Clone + 'static,
-{
-}
+impl<A> subnet::rpc::vm::Vm for Vm<A> where A: AppSender + Send + Sync + Clone + 'static {}
 
 #[tonic::async_trait]
 impl<A> snow::engine::common::vm::Vm for Vm<A>
 where
- A: AppSender + Send + Sync + Clone + 'static,
+    A: AppSender + Send + Sync + Clone + 'static,
 {
     type DatabaseManager = DatabaseManager;
     type AppSender = A;
@@ -320,7 +316,7 @@ where
 #[tonic::async_trait]
 impl<A> snowman::block::ChainVm for Vm<A>
 where
-  A: AppSender + Send + Sync + Clone + 'static,
+    A: AppSender + Send + Sync + Clone + 'static,
 {
     type Block = Block;
 
@@ -453,16 +449,15 @@ where
     }
 }
 
-impl<A: AppSender> snow::engine::common::engine::AppHandler for Vm<A>
-where
-   A: AppSender + Send + Sync + Clone + 'static,
+impl<A: AppSender> snow::engine::common::engine::AppHandler for Vm<A> where
+    A: AppSender + Send + Sync + Clone + 'static
 {
 }
 
 #[tonic::async_trait]
 impl<A> snow::engine::common::vm::Connector for Vm<A>
 where
-   A: AppSender + Send + Sync + Clone + 'static,
+    A: AppSender + Send + Sync + Clone + 'static,
 {
     async fn connected(&self, _id: &ids::node::Id) -> io::Result<()> {
         // no-op
@@ -509,7 +504,7 @@ where
 #[tonic::async_trait]
 impl<A> snowman::block::Parser for Vm<A>
 where
-   A: AppSender + Send + Sync + Clone + 'static,
+    A: AppSender + Send + Sync + Clone + 'static,
 {
     type Block = Block;
 

--- a/timestampvm/src/vm/mod.rs
+++ b/timestampvm/src/vm/mod.rs
@@ -9,7 +9,15 @@ use std::{
 use crate::{api, block::Block, genesis::Genesis, state};
 use avalanche_types::{
     choices, ids,
-    subnet::{self, rpc::snow},
+    subnet::{
+        self,
+        rpc::{
+            database::manager::{DatabaseManager, Manager},
+            health,
+            snow::{self, engine::common::appsender::AppSender},
+            snowman,
+        },
+    },
 };
 use chrono::{DateTime, Utc};
 use semver::Version;
@@ -56,23 +64,32 @@ impl Default for VmState {
 
 /// Implements [`snowman.block.ChainVM`](https://pkg.go.dev/github.com/ava-labs/avalanchego/snow/engine/snowman/block#ChainVM) interface.
 #[derive(Clone)]
-pub struct Vm {
+pub struct Vm<A>
+where
+  A: AppSender + Send + Sync + Clone + 'static,
+{
     /// Maintains the Vm-specific states.
     pub state: Arc<RwLock<VmState>>,
-    pub app_sender: Option<Box<dyn snow::engine::common::appsender::AppSender + Send + Sync>>,
+    pub app_sender: Option<A>,
 
     /// A queue of data that have not been put into a block and proposed yet.
     /// Mempool is not persistent, so just keep in memory via Vm.
     pub mempool: Arc<RwLock<VecDeque<Vec<u8>>>>,
 }
 
-impl Default for Vm {
+impl<A> Default for Vm<A>
+where
+A: AppSender + Send + Sync + Clone + 'static,
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl Vm {
+impl<A> Vm<A>
+where
+    A: AppSender + Send + Sync + Clone + 'static,
+{
     pub fn new() -> Self {
         Self {
             state: Arc::new(RwLock::new(VmState::default())),
@@ -177,20 +194,30 @@ impl Vm {
     }
 }
 
-impl subnet::rpc::vm::Vm for Vm {}
+impl<A> subnet::rpc::vm::Vm for Vm<A>
+where
+A: AppSender + Send + Sync + Clone + 'static,
+{
+}
 
 #[tonic::async_trait]
-impl snow::engine::common::vm::Vm for Vm {
+impl<A> snow::engine::common::vm::Vm for Vm<A>
+where
+ A: AppSender + Send + Sync + Clone + 'static,
+{
+    type DatabaseManager = DatabaseManager;
+    type AppSender = A;
+
     async fn initialize(
         &mut self,
         ctx: Option<subnet::rpc::context::Context>,
-        db_manager: Box<dyn subnet::rpc::database::manager::Manager + Send + Sync>,
+        db_manager: Self::DatabaseManager,
         genesis_bytes: &[u8],
         _upgrade_bytes: &[u8],
         _config_bytes: &[u8],
         to_engine: Sender<snow::engine::common::message::Message>,
         _fxs: &[snow::engine::common::vm::Fx],
-        app_sender: Box<dyn snow::engine::common::appsender::AppSender + Send + Sync>,
+        app_sender: Self::AppSender,
     ) -> io::Result<()> {
         log::info!("initializing Vm");
         let mut vm_state = self.state.write().await;
@@ -291,11 +318,14 @@ impl snow::engine::common::vm::Vm for Vm {
 }
 
 #[tonic::async_trait]
-impl subnet::rpc::snowman::block::ChainVm for Vm {
+impl<A> snowman::block::ChainVm for Vm<A>
+where
+  A: AppSender + Send + Sync + Clone + 'static,
+{
+    type Block = Block;
+
     /// Builds a block from mempool data.
-    async fn build_block(
-        &self,
-    ) -> io::Result<Box<dyn subnet::rpc::consensus::snowman::Block + Send + Sync>> {
+    async fn build_block(&self) -> io::Result<<Self as snowman::block::ChainVm>::Block> {
         let mut mempool = self.mempool.write().await;
 
         log::info!("build_block called for {} mempool", mempool.len());
@@ -324,7 +354,7 @@ impl subnet::rpc::snowman::block::ChainVm for Vm {
             block.verify().await?;
 
             log::info!("successfully built block");
-            return Ok(Box::new(block));
+            return Ok(block);
         }
 
         Err(Error::new(ErrorKind::NotFound, "state manager not found"))
@@ -338,9 +368,7 @@ impl subnet::rpc::snowman::block::ChainVm for Vm {
         self.last_accepted().await
     }
 
-    async fn issue_tx(
-        &self,
-    ) -> io::Result<Box<dyn subnet::rpc::consensus::snowman::Block + Send + Sync>> {
+    async fn issue_tx(&self) -> io::Result<<Self as snowman::block::ChainVm>::Block> {
         Err(Error::new(
             ErrorKind::Unsupported,
             "issue_tx not implemented",
@@ -349,7 +377,10 @@ impl subnet::rpc::snowman::block::ChainVm for Vm {
 }
 
 #[tonic::async_trait]
-impl snow::engine::common::engine::NetworkAppHandler for Vm {
+impl<A> snow::engine::common::engine::NetworkAppHandler for Vm<A>
+where
+    A: AppSender + Send + Sync + Clone + 'static,
+{
     /// Currently, no app-specific messages, so returning Ok.
     async fn app_request(
         &self,
@@ -387,7 +418,10 @@ impl snow::engine::common::engine::NetworkAppHandler for Vm {
 }
 
 #[tonic::async_trait]
-impl snow::engine::common::engine::CrossChainAppHandler for Vm {
+impl<A> snow::engine::common::engine::CrossChainAppHandler for Vm<A>
+where
+    A: AppSender + Send + Sync + Clone + 'static,
+{
     /// Currently, no cross chain specific messages, so returning Ok.
     async fn cross_chain_app_request(
         &self,
@@ -419,10 +453,17 @@ impl snow::engine::common::engine::CrossChainAppHandler for Vm {
     }
 }
 
-impl snow::engine::common::engine::AppHandler for Vm {}
+impl<A: AppSender> snow::engine::common::engine::AppHandler for Vm<A>
+where
+   A: AppSender + Send + Sync + Clone + 'static,
+{
+}
 
 #[tonic::async_trait]
-impl snow::engine::common::vm::Connector for Vm {
+impl<A> snow::engine::common::vm::Connector for Vm<A>
+where
+   A: AppSender + Send + Sync + Clone + 'static,
+{
     async fn connected(&self, _id: &ids::node::Id) -> io::Result<()> {
         // no-op
         Ok(())
@@ -435,22 +476,30 @@ impl snow::engine::common::vm::Connector for Vm {
 }
 
 #[tonic::async_trait]
-impl subnet::rpc::health::Checkable for Vm {
+impl<A> health::Checkable for Vm<A>
+where
+    A: AppSender + Send + Sync + Clone + 'static,
+{
     async fn health_check(&self) -> io::Result<Vec<u8>> {
         Ok("200".as_bytes().to_vec())
     }
 }
 
 #[tonic::async_trait]
-impl subnet::rpc::snowman::block::Getter for Vm {
+impl<A> snowman::block::Getter for Vm<A>
+where
+    A: AppSender + Send + Sync + Clone + 'static,
+{
+    type Block = Block;
+
     async fn get_block(
         &self,
         blk_id: ids::Id,
-    ) -> io::Result<Box<dyn subnet::rpc::consensus::snowman::Block + Send + Sync>> {
+    ) -> io::Result<<Self as snowman::block::Getter>::Block> {
         let vm_state = self.state.read().await;
         if let Some(state) = &vm_state.state {
             let block = state.get_block(&blk_id).await?;
-            return Ok(Box::new(block));
+            return Ok(block);
         }
 
         Err(Error::new(ErrorKind::NotFound, "state manager not found"))
@@ -458,11 +507,16 @@ impl subnet::rpc::snowman::block::Getter for Vm {
 }
 
 #[tonic::async_trait]
-impl subnet::rpc::snowman::block::Parser for Vm {
+impl<A> snowman::block::Parser for Vm<A>
+where
+   A: AppSender + Send + Sync + Clone + 'static,
+{
+    type Block = Block;
+
     async fn parse_block(
         &self,
         bytes: &[u8],
-    ) -> io::Result<Box<dyn subnet::rpc::consensus::snowman::Block + Send + Sync>> {
+    ) -> io::Result<<Self as snowman::block::Parser>::Block> {
         let vm_state = self.state.read().await;
         if let Some(state) = &vm_state.state {
             let mut new_block = Block::from_slice(bytes)?;
@@ -473,9 +527,9 @@ impl subnet::rpc::snowman::block::Parser for Vm {
             match state.get_block(&new_block.id()).await {
                 Ok(prev) => {
                     log::debug!("returning previously parsed block {}", prev.id());
-                    return Ok(Box::new(prev));
+                    return Ok(prev);
                 }
-                Err(_) => return Ok(Box::new(new_block)),
+                Err(_) => return Ok(new_block),
             };
         }
 


### PR DESCRIPTION
This PR adds support for AvalancheGo v1.9.10, v1.9.11+ via protocol version 24[1].

Closes #110, #113

[1] https://github.com/ava-labs/avalanchego-internal/tree/dev/proto#protocol-version-compatibility