### PR TITLE
0.0.12: add support for generic handlers

### DIFF
--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -11,9 +11,9 @@ homepage = "https://avax.network"
 [dependencies]
 
 [dev-dependencies]
-avalanche-installer = "0.0.50"
+avalanche-installer = "0.0.54"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.319", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.322", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
 env_logger = "0.10.0"
 log = "0.4.17"
 random-manager = "0.0.5"

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -11,9 +11,9 @@ homepage = "https://avax.network"
 [dependencies]
 
 [dev-dependencies]
-avalanche-installer = "0.0.54"
+avalanche-installer = "0.0.55"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.322", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.323", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
 env_logger = "0.10.0"
 log = "0.4.17"
 random-manager = "0.0.5"

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use avalanche_network_runner_sdk::{BlockchainSpec, Client, GlobalConfig, StartRequest};
 use avalanche_types::{ids, jsonrpc::client::info as avalanche_sdk_info, subnet};
 
-const AVALANCHEGO_VERSION: &str = "v1.9.14";
+const AVALANCHEGO_VERSION: &str = "v1.9.15";
 
 #[tokio::test]
 async fn e2e() {

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use avalanche_network_runner_sdk::{BlockchainSpec, Client, GlobalConfig, StartRequest};
 use avalanche_types::{ids, jsonrpc::client::info as avalanche_sdk_info, subnet};
 
-const AVALANCHEGO_VERSION: &str = "v1.9.11";
+const AVALANCHEGO_VERSION: &str = "v1.9.14";
 
 #[tokio::test]
 async fn e2e() {

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -11,8 +11,9 @@ repository = "https://github.com/ava-labs/timestampvm-rs"
 readme = "../README.md"
 
 [dependencies]
-avalanche-types = { version = "0.0.319", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.322", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
 base64 = { version = "0.21.0" }
+bytes = "1.4.0"
 chrono = "0.4.23"
 clap = { version = "4.1.8", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 derivative = "2.2.0"

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ava-labs/timestampvm-rs"
 readme = "../README.md"
 
 [dependencies]
-avalanche-types = { version = "0.0.322", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.323", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
 base64 = { version = "0.21.0" }
 bytes = "1.4.0"
 chrono = "0.4.23"

--- a/timestampvm/src/api/chain_handlers.rs
+++ b/timestampvm/src/api/chain_handlers.rs
@@ -171,7 +171,7 @@ where
         req: &Bytes,
         _headers: &[Element],
     ) -> std::io::Result<(Bytes, Vec<Element>)> {
-        match self.handler.handle_request(&de_request(&req)?).await {
+        match self.handler.handle_request(&de_request(req)?).await {
             Some(resp) => Ok((Bytes::from(resp), Vec::new())),
             None => Err(io::Error::new(
                 io::ErrorKind::Other,

--- a/timestampvm/src/api/chain_handlers.rs
+++ b/timestampvm/src/api/chain_handlers.rs
@@ -1,13 +1,16 @@
 //! Implements chain/VM specific handlers.
 //! To be served via `[HOST]/ext/bc/[CHAIN ID]/rpc`.
 
-use std::str::FromStr;
+use std::{io, marker::PhantomData, str::FromStr};
 
 use crate::{block::Block, vm::Vm};
-use avalanche_types::ids;
-use jsonrpc_core::{BoxFuture, Error, ErrorCode, Result};
+use avalanche_types::{ids, proto::http::Element, subnet::rpc::http::handle::Handle};
+use bytes::Bytes;
+use jsonrpc_core::{BoxFuture, Error, ErrorCode, IoHandler, Result};
 use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
+
+use super::de_request;
 
 /// Defines RPCs specific to the chain.
 #[rpc]
@@ -60,17 +63,18 @@ pub struct GetBlockResponse {
 }
 
 /// Implements API services for the chain-specific handlers.
-pub struct Service<A> {
+#[derive(Clone)]
+pub struct ChainService<A> {
     pub vm: Vm<A>,
 }
 
-impl<A> Service<A> {
+impl<A> ChainService<A> {
     pub fn new(vm: Vm<A>) -> Self {
         Self { vm }
     }
 }
 
-impl<A> Rpc for Service<A>
+impl<A> Rpc for ChainService<A>
 where
     A: Send + Sync + Clone + 'static,
 {
@@ -137,6 +141,43 @@ where
                 data: None,
             })
         })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ChainHandler<T> {
+    pub handler: IoHandler,
+    _marker: PhantomData<T>,
+}
+
+impl<T: Rpc> ChainHandler<T> {
+    pub fn new(service: T) -> Self {
+        let mut handler = jsonrpc_core::IoHandler::new();
+        handler.extend_with(Rpc::to_delegate(service));
+        Self {
+            handler,
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl<T> Handle for ChainHandler<T>
+where
+    T: Rpc + Send + Sync + Clone + 'static,
+{
+    async fn request(
+        &self,
+        req: &Bytes,
+        _headers: &[Element],
+    ) -> std::io::Result<(Bytes, Vec<Element>)> {
+        match self.handler.handle_request(&de_request(&req)?).await {
+            Some(resp) => Ok((Bytes::from(resp), Vec::new())),
+            None => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to handle request",
+            )),
+        }
     }
 }
 

--- a/timestampvm/src/api/mod.rs
+++ b/timestampvm/src/api/mod.rs
@@ -4,9 +4,29 @@
 pub mod chain_handlers;
 pub mod static_handlers;
 
+use std::io;
+
+use bytes::Bytes;
+use jsonrpc_core::MethodCall;
 use serde::{Deserialize, Serialize};
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct PingResponse {
     pub success: bool,
+}
+
+/// Deserializes JSON-RPC method call.
+pub fn de_request(req: &Bytes) -> io::Result<String> {
+    let method_call: MethodCall = serde_json::from_slice(req).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("failed to deserialize request: {e}"),
+        )
+    })?;
+    serde_json::to_string(&method_call).map_err(|e| {
+        io::Error::new(
+            io::ErrorKind::Other,
+            format!("failed to serialize request: {e}"),
+        )
+    })
 }

--- a/timestampvm/src/api/static_handlers.rs
+++ b/timestampvm/src/api/static_handlers.rs
@@ -53,7 +53,7 @@ impl Handle for StaticHandler {
         req: &Bytes,
         _headers: &[Element],
     ) -> std::io::Result<(Bytes, Vec<Element>)> {
-        match self.handler.handle_request(&de_request(&req)?).await {
+        match self.handler.handle_request(&de_request(req)?).await {
             Some(resp) => Ok((Bytes::from(resp), Vec::new())),
             None => Err(io::Error::new(
                 io::ErrorKind::Other,

--- a/timestampvm/src/api/static_handlers.rs
+++ b/timestampvm/src/api/static_handlers.rs
@@ -1,9 +1,14 @@
 //! Implements static handlers specific to this VM.
 //! To be served via `[HOST]/ext/vm/[VM ID]/static`.
 
-use crate::vm::Vm;
-use jsonrpc_core::{BoxFuture, Result};
+use std::io;
+
+use avalanche_types::{proto::http::Element, subnet::rpc::http::handle::Handle};
+use bytes::Bytes;
+use jsonrpc_core::{BoxFuture, IoHandler, Result};
 use jsonrpc_derive::rpc;
+
+use super::de_request;
 
 /// Defines static handler RPCs for this VM.
 #[rpc]
@@ -13,22 +18,47 @@ pub trait Rpc {
 }
 
 /// Implements API services for the static handlers.
-pub struct Service<A> {
-    pub vm: Vm<A>,
-}
+#[derive(Default)]
+pub struct StaticService {}
 
-impl<A> Service<A> {
-    pub fn new(vm: Vm<A>) -> Self {
-        Self { vm }
+impl StaticService {
+    pub fn new() -> Self {
+        Self {}
     }
 }
 
-impl<A> Rpc for Service<A>
-where
-    A: Send + Sync + Clone + 'static,
-{
+impl Rpc for StaticService {
     fn ping(&self) -> BoxFuture<Result<crate::api::PingResponse>> {
         log::debug!("ping called");
         Box::pin(async move { Ok(crate::api::PingResponse { success: true }) })
+    }
+}
+#[derive(Clone)]
+pub struct StaticHandler {
+    pub handler: IoHandler,
+}
+
+impl StaticHandler {
+    pub fn new(service: StaticService) -> Self {
+        let mut handler = jsonrpc_core::IoHandler::new();
+        handler.extend_with(Rpc::to_delegate(service));
+        Self { handler }
+    }
+}
+
+#[tonic::async_trait]
+impl Handle for StaticHandler {
+    async fn request(
+        &self,
+        req: &Bytes,
+        _headers: &[Element],
+    ) -> std::io::Result<(Bytes, Vec<Element>)> {
+        match self.handler.handle_request(&de_request(&req)?).await {
+            Some(resp) => Ok((Bytes::from(resp), Vec::new())),
+            None => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "failed to handle request",
+            )),
+        }
     }
 }


### PR DESCRIPTION
This PR bumps e2e testing against AvalancheGo@v1.9.15 and implements an example of the new generic HTTP handler support using `jsonrpc`[1].

[1] https://github.com/paritytech/jsonrpc