### PR TITLE
Make clippy-pedantic happy

### DIFF
--- a/tests/e2e/src/lib.rs
+++ b/tests/e2e/src/lib.rs
@@ -1,6 +1,7 @@
 #[cfg(test)]
 mod tests;
 
+#[must_use]
 pub fn get_network_runner_grpc_endpoint() -> (String, bool) {
     match std::env::var("NETWORK_RUNNER_GRPC_ENDPOINT") {
         Ok(s) => (s, true),
@@ -8,10 +9,12 @@ pub fn get_network_runner_grpc_endpoint() -> (String, bool) {
     }
 }
 
+#[must_use]
 pub fn get_network_runner_enable_shutdown() -> bool {
     matches!(std::env::var("NETWORK_RUNNER_ENABLE_SHUTDOWN"), Ok(_))
 }
 
+#[must_use]
 pub fn get_avalanchego_path() -> (String, bool) {
     match std::env::var("AVALANCHEGO_PATH") {
         Ok(s) => (s, true),
@@ -19,6 +22,7 @@ pub fn get_avalanchego_path() -> (String, bool) {
     }
 }
 
+#[must_use]
 pub fn get_vm_plugin_path() -> (String, bool) {
     match std::env::var("VM_PLUGIN_PATH") {
         Ok(s) => (s, true),

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -204,7 +204,7 @@ async fn e2e() {
     log::info!("network Id: {}", network_id);
 
     log::info!("ping static handlers");
-    let static_url_path = format!("ext/vm/{}/static", vm_id);
+    let static_url_path = format!("ext/vm/{vm_id}/static");
     for ep in rpc_eps.iter() {
         let resp = timestampvm::client::ping(ep.as_str(), &static_url_path)
             .await
@@ -216,7 +216,7 @@ async fn e2e() {
     }
 
     log::info!("ping chain handlers");
-    let chain_url_path = format!("ext/bc/{}/rpc", blockchain_id);
+    let chain_url_path = format!("ext/bc/{blockchain_id}/rpc");
     for ep in rpc_eps.iter() {
         let resp = timestampvm::client::ping(ep.as_str(), &chain_url_path)
             .await

--- a/timestampvm/src/api/chain_handlers.rs
+++ b/timestampvm/src/api/chain_handlers.rs
@@ -1,14 +1,13 @@
 //! Implements chain/VM specific handlers.
 //! To be served via `[HOST]/ext/bc/[CHAIN ID]/rpc`.
 
-use std::{io, marker::PhantomData, str::FromStr};
-
 use crate::{block::Block, vm::Vm};
 use avalanche_types::{ids, proto::http::Element, subnet::rpc::http::handle::Handle};
 use bytes::Bytes;
 use jsonrpc_core::{BoxFuture, Error, ErrorCode, IoHandler, Result};
 use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
+use std::{io, marker::PhantomData, str::FromStr};
 
 use super::de_request;
 

--- a/timestampvm/src/api/chain_handlers.rs
+++ b/timestampvm/src/api/chain_handlers.rs
@@ -183,6 +183,6 @@ where
 
 fn create_jsonrpc_error(e: std::io::Error) -> Error {
     let mut error = Error::new(ErrorCode::InternalError);
-    error.message = format!("{}", e);
+    error.message = format!("{e}");
     error
 }

--- a/timestampvm/src/api/chain_handlers.rs
+++ b/timestampvm/src/api/chain_handlers.rs
@@ -7,7 +7,7 @@ use bytes::Bytes;
 use jsonrpc_core::{BoxFuture, Error, ErrorCode, IoHandler, Result};
 use jsonrpc_derive::rpc;
 use serde::{Deserialize, Serialize};
-use std::{io, marker::PhantomData, str::FromStr};
+use std::{borrow::Borrow, io, marker::PhantomData, str::FromStr};
 
 use super::de_request;
 
@@ -180,7 +180,8 @@ where
     }
 }
 
-fn create_jsonrpc_error(e: std::io::Error) -> Error {
+fn create_jsonrpc_error<E: Borrow<std::io::Error>>(e: E) -> Error {
+    let e = e.borrow();
     let mut error = Error::new(ErrorCode::InternalError);
     error.message = format!("{e}");
     error

--- a/timestampvm/src/api/mod.rs
+++ b/timestampvm/src/api/mod.rs
@@ -16,6 +16,8 @@ pub struct PingResponse {
 }
 
 /// Deserializes JSON-RPC method call.
+/// # Errors
+/// Fails if the request is not a valid JSON-RPC method call.
 pub fn de_request(req: &Bytes) -> io::Result<String> {
     let method_call: MethodCall = serde_json::from_slice(req).map_err(|e| {
         io::Error::new(

--- a/timestampvm/src/api/static_handlers.rs
+++ b/timestampvm/src/api/static_handlers.rs
@@ -22,6 +22,7 @@ pub trait Rpc {
 pub struct StaticService {}
 
 impl StaticService {
+    #[must_use]
     pub fn new() -> Self {
         Self {}
     }
@@ -39,6 +40,7 @@ pub struct StaticHandler {
 }
 
 impl StaticHandler {
+    #[must_use]
     pub fn new(service: StaticService) -> Self {
         let mut handler = jsonrpc_core::IoHandler::new();
         handler.extend_with(Rpc::to_delegate(service));

--- a/timestampvm/src/bin/timestampvm/genesis.rs
+++ b/timestampvm/src/bin/timestampvm/genesis.rs
@@ -2,6 +2,7 @@ use clap::{arg, Command};
 
 pub const NAME: &str = "genesis";
 
+#[must_use]
 pub fn command() -> Command {
     Command::new(NAME)
         .about("Write a genesis file")

--- a/timestampvm/src/bin/timestampvm/vm_id.rs
+++ b/timestampvm/src/bin/timestampvm/vm_id.rs
@@ -2,6 +2,7 @@ use clap::{arg, Command};
 
 pub const NAME: &str = "vm-id";
 
+#[must_use]
 pub fn command() -> Command {
     Command::new(NAME)
         .about("Converts a given Vm name string to Vm Id")

--- a/timestampvm/src/block/mod.rs
+++ b/timestampvm/src/block/mod.rs
@@ -263,9 +263,6 @@ impl Block {
     }
 }
 
-/// ref. https://doc.rust-lang.org/std/string/trait.ToString.html
-/// ref. https://doc.rust-lang.org/std/fmt/trait.Display.html
-/// Use "Self.to_string()" to directly invoke this
 impl fmt::Display for Block {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let serialized = self.to_json_string().unwrap();

--- a/timestampvm/src/block/mod.rs
+++ b/timestampvm/src/block/mod.rs
@@ -93,6 +93,8 @@ impl Block {
         Ok(b)
     }
 
+    /// # Errors
+    /// Can fail if the block can't be serialized to JSON.
     pub fn to_json_string(&self) -> io::Result<String> {
         serde_json::to_string(&self).map_err(|e| {
             Error::new(
@@ -113,6 +115,8 @@ impl Block {
     }
 
     /// Loads [`Block`](Block) from JSON bytes.
+    /// # Errors
+    /// Will fail if the block can't be deserialized from JSON.
     pub fn from_slice(d: impl AsRef<[u8]>) -> io::Result<Self> {
         let dd = d.as_ref();
         let mut b: Self = serde_json::from_slice(dd).map_err(|e| {
@@ -182,6 +186,8 @@ impl Block {
 
     /// Verifies [`Block`](Block) properties (e.g., heights),
     /// and once verified, records it to the [`State`](crate::state::State).
+    /// # Errors
+    /// Can fail if the parent block can't be retrieved.
     pub async fn verify(&mut self) -> io::Result<()> {
         if self.height == 0 && self.parent_id == ids::Id::empty() {
             log::debug!(
@@ -240,6 +246,8 @@ impl Block {
     }
 
     /// Mark this [`Block`](Block) accepted and updates [`State`](crate::state::State) accordingly.
+    /// # Errors
+    /// Returns an error if the state can't be updated.
     pub async fn accept(&mut self) -> io::Result<()> {
         self.set_status(choices::status::Status::Accepted);
 
@@ -252,6 +260,8 @@ impl Block {
     }
 
     /// Mark this [`Block`](Block) rejected and updates [`State`](crate::state::State) accordingly.
+    /// # Errors
+    /// Returns an error if the state can't be updated.
     pub async fn reject(&mut self) -> io::Result<()> {
         self.set_status(choices::status::Status::Rejected);
 

--- a/timestampvm/src/block/mod.rs
+++ b/timestampvm/src/block/mod.rs
@@ -213,8 +213,14 @@ impl Block {
             ));
         }
 
+        let one_hour_from_now = Utc::now() + Duration::hours(1);
+        let one_hour_from_now = one_hour_from_now
+            .timestamp()
+            .try_into()
+            .expect("failed to convert timestamp from i64 to u64");
+
         // ensure block timestamp is no more than an hour ahead of this nodes time
-        if self.timestamp >= (Utc::now() + Duration::hours(1)).timestamp() as u64 {
+        if self.timestamp >= one_hour_from_now {
             return Err(Error::new(
                 ErrorKind::InvalidData,
                 format!(

--- a/timestampvm/src/block/mod.rs
+++ b/timestampvm/src/block/mod.rs
@@ -129,26 +129,31 @@ impl Block {
     }
 
     /// Returns the parent block Id.
+    #[must_use]
     pub fn parent_id(&self) -> ids::Id {
         self.parent_id
     }
 
     /// Returns the height of this block.
+    #[must_use]
     pub fn height(&self) -> u64 {
         self.height
     }
 
     /// Returns the timestamp of this block.
+    #[must_use]
     pub fn timestamp(&self) -> u64 {
         self.timestamp
     }
 
     /// Returns the data of this block.
+    #[must_use]
     pub fn data(&self) -> &[u8] {
         &self.data
     }
 
     /// Returns the status of this block.
+    #[must_use]
     pub fn status(&self) -> choices::status::Status {
         self.status.clone()
     }
@@ -159,11 +164,13 @@ impl Block {
     }
 
     /// Returns the byte representation of this block.
+    #[must_use]
     pub fn bytes(&self) -> &[u8] {
         &self.bytes
     }
 
     /// Returns the ID of this block
+    #[must_use]
     pub fn id(&self) -> ids::Id {
         self.id
     }

--- a/timestampvm/src/block/mod.rs
+++ b/timestampvm/src/block/mod.rs
@@ -69,7 +69,7 @@ impl Block {
         };
 
         b.status = status;
-        b.bytes = b.to_slice()?;
+        b.bytes = b.to_vec()?;
         b.id = ids::Id::sha256(&b.bytes);
 
         Ok(b)
@@ -87,7 +87,9 @@ impl Block {
     }
 
     /// Encodes the [`Block`](Block) to JSON in bytes.
-    pub fn to_slice(&self) -> io::Result<Vec<u8>> {
+    /// # Errors
+    /// Errors if the block can't be serialized to JSON.
+    pub fn to_vec(&self) -> io::Result<Vec<u8>> {
         serde_json::to_vec(&self).map_err(|e| {
             Error::new(
                 ErrorKind::Other,
@@ -283,7 +285,7 @@ async fn test_block() {
     .unwrap();
     log::info!("deserialized: {genesis_blk} (block Id: {})", genesis_blk.id);
 
-    let serialized = genesis_blk.to_slice().unwrap();
+    let serialized = genesis_blk.to_vec().unwrap();
     let deserialized = Block::from_slice(&serialized).unwrap();
     log::info!("deserialized: {deserialized}");
 

--- a/timestampvm/src/block/mod.rs
+++ b/timestampvm/src/block/mod.rs
@@ -19,7 +19,7 @@ use serde_with::serde_as;
 
 /// Represents a block, specific to [`Vm`](crate::vm::Vm).
 #[serde_as]
-#[derive(Serialize, Deserialize, Clone, Derivative)]
+#[derive(Serialize, Deserialize, Clone, Derivative, Default)]
 #[derivative(Debug, PartialEq, Eq)]
 pub struct Block {
     /// The block Id of the parent block.
@@ -49,28 +49,7 @@ pub struct Block {
     state: state::State,
 }
 
-impl Default for Block {
-    fn default() -> Self {
-        Self::default()
-    }
-}
-
 impl Block {
-    pub fn default() -> Self {
-        Self {
-            parent_id: ids::Id::empty(),
-            height: 0,
-            timestamp: 0,
-            data: Vec::new(),
-
-            status: choices::status::Status::default(),
-            bytes: Vec::new(),
-            id: ids::Id::empty(),
-
-            state: state::State::default(),
-        }
-    }
-
     pub fn new(
         parent_id: ids::Id,
         height: u64,

--- a/timestampvm/src/block/mod.rs
+++ b/timestampvm/src/block/mod.rs
@@ -50,7 +50,10 @@ pub struct Block {
 }
 
 impl Block {
-    pub fn new(
+    /// Can fail if the block can't be serialized to JSON.
+    /// # Errors
+    /// Will fail if the block can't be serialized to JSON.
+    pub fn try_new(
         parent_id: ids::Id,
         height: u64,
         timestamp: u64,
@@ -270,7 +273,7 @@ async fn test_block() {
         .is_test(true)
         .try_init();
 
-    let mut genesis_blk = Block::new(
+    let mut genesis_blk = Block::try_new(
         ids::Id::empty(),
         0,
         Utc::now().timestamp() as u64,
@@ -308,7 +311,7 @@ async fn test_block() {
     let read_blk = state.get_block(&genesis_blk.id()).await.unwrap();
     assert_eq!(genesis_blk, read_blk);
 
-    let mut blk1 = Block::new(
+    let mut blk1 = Block::try_new(
         genesis_blk.id,
         genesis_blk.height + 1,
         genesis_blk.timestamp + 1,
@@ -332,7 +335,7 @@ async fn test_block() {
     let read_blk = state.get_block(&blk1.id()).await.unwrap();
     assert_eq!(blk1, read_blk);
 
-    let mut blk2 = Block::new(
+    let mut blk2 = Block::try_new(
         blk1.id,
         blk1.height + 1,
         blk1.timestamp + 1,
@@ -357,7 +360,7 @@ async fn test_block() {
     let read_blk = state.get_block(&blk2.id()).await.unwrap();
     assert_eq!(blk2, read_blk);
 
-    let mut blk3 = Block::new(
+    let mut blk3 = Block::try_new(
         blk2.id,
         blk2.height - 1,
         blk2.timestamp + 1,
@@ -373,7 +376,7 @@ async fn test_block() {
     assert!(state.has_last_accepted_block().await.unwrap());
 
     // blk4 built from blk2 has invalid timestamp built 2 hours in future
-    let mut blk4 = Block::new(
+    let mut blk4 = Block::try_new(
         blk2.id,
         blk2.height + 1,
         (Utc::now() + Duration::hours(2)).timestamp() as u64,

--- a/timestampvm/src/block/mod.rs
+++ b/timestampvm/src/block/mod.rs
@@ -97,7 +97,7 @@ impl Block {
         serde_json::to_string(&self).map_err(|e| {
             Error::new(
                 ErrorKind::Other,
-                format!("failed to serialize Block to JSON string {}", e),
+                format!("failed to serialize Block to JSON string {e}"),
             )
         })
     }
@@ -107,7 +107,7 @@ impl Block {
         serde_json::to_vec(&self).map_err(|e| {
             Error::new(
                 ErrorKind::Other,
-                format!("failed to serialize Block to JSON bytes {}", e),
+                format!("failed to serialize Block to JSON bytes {e}"),
             )
         })
     }
@@ -118,7 +118,7 @@ impl Block {
         let mut b: Self = serde_json::from_slice(dd).map_err(|e| {
             Error::new(
                 ErrorKind::Other,
-                format!("failed to deserialize Block from JSON {}", e),
+                format!("failed to deserialize Block from JSON {e}"),
             )
         })?;
 

--- a/timestampvm/src/client/mod.rs
+++ b/timestampvm/src/client/mod.rs
@@ -23,6 +23,8 @@ pub struct PingResponse {
 }
 
 /// Ping the VM.
+/// # Errors
+/// Errors on an http failure or a failed deserialization.
 pub async fn ping(http_rpc: &str, url_path: &str) -> io::Result<PingResponse> {
     log::info!("ping {http_rpc} with {url_path}");
 
@@ -51,6 +53,8 @@ pub struct LastAcceptedResponse {
 }
 
 /// Requests for the last accepted block Id.
+/// # Errors
+/// Errors on failed (de)serialization or an http failure.
 pub async fn last_accepted(http_rpc: &str, url_path: &str) -> io::Result<LastAcceptedResponse> {
     log::info!("last_accepted {http_rpc} with {url_path}");
 
@@ -79,6 +83,8 @@ pub struct GetBlockResponse {
 }
 
 /// Fetches the block for the corresponding block Id (if any).
+/// # Errors
+/// Errors on failed (de)serialization or an http failure.
 pub async fn get_block(
     http_rpc: &str,
     url_path: &str,
@@ -118,6 +124,8 @@ pub struct ProposeBlockResponse {
 }
 
 /// Proposes arbitrary data.
+/// # Errors
+/// Errors on failed (de)serialization or an http failure.
 pub async fn propose_block(
     http_rpc: &str,
     url_path: &str,

--- a/timestampvm/src/client/mod.rs
+++ b/timestampvm/src/client/mod.rs
@@ -33,7 +33,7 @@ pub async fn ping(http_rpc: &str, url_path: &str) -> io::Result<PingResponse> {
     let rb = http_manager::post_non_tls(http_rpc, url_path, &d).await?;
 
     serde_json::from_slice(&rb)
-        .map_err(|e| Error::new(ErrorKind::Other, format!("failed ping '{}'", e)))
+        .map_err(|e| Error::new(ErrorKind::Other, format!("failed ping '{e}'")))
 }
 
 /// Represents the RPC response for API `last_accepted`.
@@ -61,7 +61,7 @@ pub async fn last_accepted(http_rpc: &str, url_path: &str) -> io::Result<LastAcc
     let rb = http_manager::post_non_tls(http_rpc, url_path, &d).await?;
 
     serde_json::from_slice(&rb)
-        .map_err(|e| Error::new(ErrorKind::Other, format!("failed last_accepted '{}'", e)))
+        .map_err(|e| Error::new(ErrorKind::Other, format!("failed last_accepted '{e}'")))
 }
 
 /// Represents the RPC response for API `get_block`.
@@ -99,7 +99,7 @@ pub async fn get_block(
     let rb = http_manager::post_non_tls(http_rpc, url_path, &d).await?;
 
     serde_json::from_slice(&rb)
-        .map_err(|e| Error::new(ErrorKind::Other, format!("failed get_block '{}'", e)))
+        .map_err(|e| Error::new(ErrorKind::Other, format!("failed get_block '{e}'")))
 }
 
 /// Represents the RPC response for API `propose_block`.
@@ -141,7 +141,7 @@ pub async fn propose_block(
     let rb = http_manager::post_non_tls(http_rpc, url_path, &d).await?;
 
     serde_json::from_slice(&rb)
-        .map_err(|e| Error::new(ErrorKind::Other, format!("failed propose_block '{}'", e)))
+        .map_err(|e| Error::new(ErrorKind::Other, format!("failed propose_block '{e}'")))
 }
 
 /// Represents the error (if any) for APIs.

--- a/timestampvm/src/genesis/mod.rs
+++ b/timestampvm/src/genesis/mod.rs
@@ -25,7 +25,9 @@ impl Default for Genesis {
 
 impl Genesis {
     /// Encodes the genesis to JSON bytes.
-    pub fn to_slice(&self) -> io::Result<Vec<u8>> {
+    /// # Errors
+    /// Fails if `Self` can't be serialized
+    pub fn to_vec(&self) -> io::Result<Vec<u8>> {
         serde_json::to_vec(&self).map_err(|e| {
             Error::new(
                 ErrorKind::Other,

--- a/timestampvm/src/genesis/mod.rs
+++ b/timestampvm/src/genesis/mod.rs
@@ -33,7 +33,7 @@ impl Genesis {
         serde_json::to_vec(&self).map_err(|e| {
             Error::new(
                 ErrorKind::Other,
-                format!("failed to serialize Genesis to JSON bytes {}", e),
+                format!("failed to serialize Genesis to JSON bytes {e}"),
             )
         })
     }
@@ -43,7 +43,7 @@ impl Genesis {
         S: AsRef<[u8]>,
     {
         serde_json::from_slice(d.as_ref())
-            .map_err(|e| Error::new(ErrorKind::Other, format!("failed to decode {}", e)))
+            .map_err(|e| Error::new(ErrorKind::Other, format!("failed to decode {e}")))
     }
 
     /// Persists the genesis to a file.
@@ -57,7 +57,7 @@ impl Genesis {
         let d = serde_json::to_vec(&self).map_err(|e| {
             Error::new(
                 ErrorKind::Other,
-                format!("failed to serialize genesis info to JSON {}", e),
+                format!("failed to serialize genesis info to JSON {e}"),
             )
         })?;
 
@@ -71,6 +71,6 @@ impl Genesis {
 impl fmt::Display for Genesis {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let s = serde_json::to_string(&self).unwrap();
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }

--- a/timestampvm/src/genesis/mod.rs
+++ b/timestampvm/src/genesis/mod.rs
@@ -17,17 +17,13 @@ pub struct Genesis {
 
 impl Default for Genesis {
     fn default() -> Self {
-        Self::default()
-    }
-}
-
-impl Genesis {
-    pub fn default() -> Self {
         Self {
             data: String::from("Hello from Rust VM!"),
         }
     }
+}
 
+impl Genesis {
     /// Encodes the genesis to JSON bytes.
     pub fn to_slice(&self) -> io::Result<Vec<u8>> {
         serde_json::to_vec(&self).map_err(|e| {

--- a/timestampvm/src/genesis/mod.rs
+++ b/timestampvm/src/genesis/mod.rs
@@ -38,6 +38,9 @@ impl Genesis {
         })
     }
 
+    /// Decodes the genesis from JSON bytes.
+    /// # Errors
+    /// Fails if the bytes can't be deserialized
     pub fn from_slice<S>(d: S) -> io::Result<Self>
     where
         S: AsRef<[u8]>,
@@ -47,6 +50,8 @@ impl Genesis {
     }
 
     /// Persists the genesis to a file.
+    /// # Errors
+    /// Fails if the file can't be created, written to, or if `self` can't be serialized
     pub fn sync(&self, file_path: &str) -> io::Result<()> {
         log::info!("syncing genesis to '{}'", file_path);
 

--- a/timestampvm/src/genesis/mod.rs
+++ b/timestampvm/src/genesis/mod.rs
@@ -54,7 +54,7 @@ impl Genesis {
         log::info!("syncing genesis to '{}'", file_path);
 
         let path = Path::new(file_path);
-        let parent_dir = path.parent().unwrap();
+        let parent_dir = path.parent().expect("Invalid path");
         fs::create_dir_all(parent_dir)?;
 
         let d = serde_json::to_vec(&self).map_err(|e| {

--- a/timestampvm/src/lib.rs
+++ b/timestampvm/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This project implements timestampvm that allows anyone to propose and read
 //! blocks, each of which is tagged with the proposed timestamp. It implements
-//! the snowman block.ChainVM interface in Rust, pluggable to AvalancheGo nodes.
+//! the snowman block.ChainVM interface in Rust, pluggable to `AvalancheGo` nodes.
 //!
 //! See [`ava-labs/timestampvm`](https://github.com/ava-labs/timestampvm) for the original Go implementation.
 //!

--- a/timestampvm/src/state/mod.rs
+++ b/timestampvm/src/state/mod.rs
@@ -192,7 +192,7 @@ async fn test_state() {
         .is_test(true)
         .try_init();
 
-    let genesis_blk = Block::new(
+    let genesis_blk = Block::try_new(
         ids::Id::empty(),
         0,
         random_manager::u64(),
@@ -202,7 +202,7 @@ async fn test_state() {
     .unwrap();
     log::info!("genesis block: {genesis_blk}");
 
-    let blk1 = Block::new(
+    let blk1 = Block::try_new(
         genesis_blk.id(),
         1,
         genesis_blk.timestamp() + 1,

--- a/timestampvm/src/state/mod.rs
+++ b/timestampvm/src/state/mod.rs
@@ -37,7 +37,7 @@ const STATUS_PREFIX: u8 = 0x0;
 const DELIMITER: u8 = b'/';
 
 /// Returns a vec of bytes used as a key for identifying blocks in state.
-/// 'STATUS_PREFIX' + 'BYTE_DELIMITER' + [block_id]
+/// '`STATUS_PREFIX`' + '`BYTE_DELIMITER`' + [`block_id`]
 fn block_with_status_key(blk_id: &ids::Id) -> Vec<u8> {
     let mut k: Vec<u8> = Vec::with_capacity(ids::LEN + 2);
     k.push(STATUS_PREFIX);
@@ -121,7 +121,7 @@ impl State {
         }
     }
 
-    /// Adds a block to "verified_blocks".
+    /// Adds a block to "`verified_blocks`".
     pub async fn add_verified(&mut self, block: &Block) {
         let blk_id = block.id();
         log::info!("verified added {blk_id}");
@@ -130,7 +130,7 @@ impl State {
         verified_blocks.insert(blk_id, block.clone());
     }
 
-    /// Removes a block from "verified_blocks".
+    /// Removes a block from "`verified_blocks`".
     pub async fn remove_verified(&mut self, blk_id: &ids::Id) {
         let mut verified_blocks = self.verified_blocks.write().await;
         verified_blocks.remove(blk_id);

--- a/timestampvm/src/state/mod.rs
+++ b/timestampvm/src/state/mod.rs
@@ -59,7 +59,7 @@ impl BlockWithStatus {
         serde_json::to_vec(&self).map_err(|e| {
             Error::new(
                 ErrorKind::Other,
-                format!("failed to serialize BlockStatus to JSON bytes: {}", e),
+                format!("failed to serialize BlockStatus to JSON bytes: {e}"),
             )
         })
     }
@@ -69,7 +69,7 @@ impl BlockWithStatus {
         serde_json::from_slice(dd).map_err(|e| {
             Error::new(
                 ErrorKind::Other,
-                format!("failed to deserialize BlockStatus from JSON: {}", e),
+                format!("failed to deserialize BlockStatus from JSON: {e}"),
             )
         })
     }
@@ -151,7 +151,7 @@ impl State {
 
         db.put(&block_with_status_key(&blk_id), &blk_status_bytes)
             .await
-            .map_err(|e| Error::new(ErrorKind::Other, format!("failed to put block: {:?}", e)))
+            .map_err(|e| Error::new(ErrorKind::Other, format!("failed to put block: {e:?}")))
     }
 
     /// Reads a block from the state storage using the block_with_status_key.

--- a/timestampvm/src/state/mod.rs
+++ b/timestampvm/src/state/mod.rs
@@ -147,7 +147,7 @@ impl State {
     /// Can fail if the block fails to serialize or if the db can't be updated
     pub async fn write_block(&mut self, block: &Block) -> io::Result<()> {
         let blk_id = block.id();
-        let blk_bytes = block.to_slice()?;
+        let blk_bytes = block.to_vec()?;
 
         let mut db = self.db.write().await;
 

--- a/timestampvm/src/vm/mod.rs
+++ b/timestampvm/src/vm/mod.rs
@@ -357,7 +357,10 @@ where
             // "state" must have preferred block in cache/verified_block
             // otherwise, not found error from rpcchainvm database
             let prnt_blk = state.get_block(&vm_state.preferred).await?;
-            let unix_now = Utc::now().timestamp() as u64;
+            let unix_now = Utc::now()
+                .timestamp()
+                .try_into()
+                .expect("timestamp to convert from i64 to u64");
 
             let first = mempool.pop_front().unwrap();
             let mut block = Block::try_new(

--- a/timestampvm/src/vm/mod.rs
+++ b/timestampvm/src/vm/mod.rs
@@ -134,6 +134,8 @@ where
 
     /// Proposes arbitrary data to mempool and notifies that a block is ready for builds.
     /// Other VMs may optimize mempool with more complicated batching mechanisms.
+    /// # Errors
+    /// Can fail if the data size exceeds `PROPOSE_LIMIT_BYTES`.
     pub async fn propose_block(&self, d: Vec<u8>) -> io::Result<()> {
         let size = d.len();
         log::info!("received propose_block of {size} bytes");
@@ -155,6 +157,8 @@ where
     }
 
     /// Sets the state of the Vm.
+    /// # Errors
+    /// Will fail if the `snow::State` is syncing
     pub async fn set_state(&self, snow_state: snow::State) -> io::Result<()> {
         let mut vm_state = self.state.write().await;
         match snow_state {
@@ -195,6 +199,8 @@ where
     }
 
     /// Returns the last accepted block Id.
+    /// # Errors
+    /// Will fail if there's no state or if the db can't be accessed
     pub async fn last_accepted(&self) -> io::Result<ids::Id> {
         let vm_state = self.state.read().await;
         if let Some(state) = &vm_state.state {

--- a/timestampvm/src/vm/mod.rs
+++ b/timestampvm/src/vm/mod.rs
@@ -142,10 +142,7 @@ where
             log::info!("limit exceeded... returning an error...");
             return Err(Error::new(
                 ErrorKind::InvalidInput,
-                format!(
-                    "data {}-byte exceeds the limit {}-byte",
-                    size, PROPOSE_LIMIT_BYTES
-                ),
+                format!("data {size}-byte exceeds the limit {PROPOSE_LIMIT_BYTES}-byte"),
             ));
         }
 

--- a/timestampvm/src/vm/mod.rs
+++ b/timestampvm/src/vm/mod.rs
@@ -261,7 +261,7 @@ where
             vm_state.preferred = last_accepted_blk_id;
             log::info!("initialized Vm with last accepted block {last_accepted_blk_id}");
         } else {
-            let mut genesis_block = Block::new(
+            let mut genesis_block = Block::try_new(
                 ids::Id::empty(),
                 0,
                 0,
@@ -360,7 +360,7 @@ where
             let unix_now = Utc::now().timestamp() as u64;
 
             let first = mempool.pop_front().unwrap();
-            let mut block = Block::new(
+            let mut block = Block::try_new(
                 prnt_blk.id(),
                 prnt_blk.height() + 1,
                 unix_now,

--- a/timestampvm/src/vm/mod.rs
+++ b/timestampvm/src/vm/mod.rs
@@ -103,6 +103,7 @@ impl<A> Vm<A>
 where
     A: Send + Sync + Clone + 'static,
 {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             state: Arc::new(RwLock::new(VmState::default())),

--- a/timestampvm/src/vm/mod.rs
+++ b/timestampvm/src/vm/mod.rs
@@ -47,7 +47,7 @@ pub const PROPOSE_LIMIT_BYTES: usize = 1024 * 1024;
 /// Represents VM-specific states.
 /// Defined in a separate struct, for interior mutability in [`Vm`](Vm).
 /// To be protected with `Arc` and `RwLock`.
-pub struct VmState {
+pub struct State {
     pub ctx: Option<subnet::rpc::context::Context>,
     pub version: Version,
     pub genesis: Genesis,
@@ -63,7 +63,7 @@ pub struct VmState {
     pub bootstrapped: bool,
 }
 
-impl Default for VmState {
+impl Default for State {
     fn default() -> Self {
         Self {
             ctx: None,
@@ -82,7 +82,7 @@ impl Default for VmState {
 #[derive(Clone)]
 pub struct Vm<A> {
     /// Maintains the Vm-specific states.
-    pub state: Arc<RwLock<VmState>>,
+    pub state: Arc<RwLock<State>>,
     pub app_sender: Option<A>,
 
     /// A queue of data that have not been put into a block and proposed yet.
@@ -106,7 +106,7 @@ where
     #[must_use]
     pub fn new() -> Self {
         Self {
-            state: Arc::new(RwLock::new(VmState::default())),
+            state: Arc::new(RwLock::new(State::default())),
             app_sender: None,
             mempool: Arc::new(RwLock::new(VecDeque::with_capacity(100))),
         }


### PR DESCRIPTION
The following is broken down into separate commits in case we don't want to be so strict, but the brunt of this PR makes `cargo clippy -- -W clippy::pedantic` happy. 

I strongly feel that when dealing with any Rust repos that are used as demos for the community that we should be using `clippy::pedantic`. It is strict, but it's probably the closest automated way that we can follow Rust idioms in the community, which should help in terms of adoption. 

I did make a couple other changes that weren't suggested by clippy too.

- Add must_use to functions
- Inline format args
- Add Error doc-comments
- Derive default instead of manually implementing
- No fallible new functions
- Move default function to trait implementation
- Rename to_slice to to_vec to accurately reflect types
- Remove `as` casting from timestamps
- Use expect instead of unwrap
- Doc cleanup
- Remove stutter-type in vm mod
- Move unused child method to parent
- Make create_jsonrpc_error more flexible
