### PR TITLE
Make clippy::pedantic the default

### DIFF
--- a/timestampvm/src/lib.rs
+++ b/timestampvm/src/lib.rs
@@ -38,6 +38,8 @@
 //! }
 //! ```
 
+#![deny(clippy::pedantic)]
+
 pub mod api;
 pub mod block;
 pub mod client;


### PR DESCRIPTION
Since my last PR was accepted wholesale, I figured we could make clippy::pedantic the default. From the Clippy docs:
>If you enable this group, expect to also use `#[allow]` attributes generously throughout your code. Lints in this group are designed to be pedantic and false positives sometimes are intentional in order to prevent false negatives.

If the doesn't unanimously agree on doing this, we shouldn't merge this PR.
