### PR TITLE
cargo: bump deps to support AvalancheGo@1.10.0-fuji

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ See [`bin/timestampvm`](timestampvm/src/bin/timestampvm/main.rs) for plugin impl
 | v0.0.7  | v1.9.4 |
 | v0.0.8, v0.0.9  | v1.9.7 |
 | v0.0.10 | v1.9.8, v1.9.9 |
-| v0.0.11 | v1.9.10, v1.9.11 |
+| v0.0.11,12 | v1.9.10 - v1.9.16 |
+| v0.0.13 | v1.10.0 |
 
 ## Example
 

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -11,13 +11,13 @@ homepage = "https://avax.network"
 [dependencies]
 
 [dev-dependencies]
-avalanche-installer = "0.0.55"
+avalanche-installer = "0.0.58"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.323", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.336", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
 env_logger = "0.10.0"
 log = "0.4.17"
 random-manager = "0.0.5"
 serde_json = "1.0.94" # https://github.com/serde-rs/json/releases
 tempfile = "3.4.0"
 timestampvm = { path = "../../timestampvm" }
-tokio = { version = "1.25.0", features = [] } # https://github.com/tokio-rs/tokio/releases
+tokio = { version = "1.27.0", features = [] } # https://github.com/tokio-rs/tokio/releases

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use avalanche_network_runner_sdk::{BlockchainSpec, Client, GlobalConfig, StartRequest};
 use avalanche_types::{ids, jsonrpc::client::info as avalanche_sdk_info, subnet};
 
-const AVALANCHEGO_VERSION: &str = "v1.9.15";
+const AVALANCHEGO_VERSION: &str = "v1.10.0-fuji";
 
 #[tokio::test]
 async fn e2e() {

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timestampvm"
-version = "0.0.11" # https://crates.io/crates/timestampvm
+version = "0.0.13" # https://crates.io/crates/timestampvm
 edition = "2021"
 rust-version = "1.68"
 publish = true

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ava-labs/timestampvm-rs"
 readme = "../README.md"
 
 [dependencies]
-avalanche-types = { version = "0.0.323", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.336", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
 base64 = { version = "0.21.0" }
 bytes = "1.4.0"
 chrono = "0.4.23"
@@ -27,8 +27,8 @@ semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
 serde_json = "1.0.93" # https://github.com/serde-rs/json/releases
 serde_with = { version = "2.2.0", features = ["hex"] }
-tokio = { version = "1.25.0", features = ["fs", "rt-multi-thread"] }
-tonic = { version = "0.8.3", features = ["gzip"] }
+tokio = { version = "1.27.0", features = ["fs", "rt-multi-thread"] }
+tonic = { version = "0.9.1", features = ["gzip"] }
 
 [dev-dependencies]
 random-manager = "0.0.5"

--- a/timestampvm/src/vm/mod.rs
+++ b/timestampvm/src/vm/mod.rs
@@ -20,6 +20,7 @@ use avalanche_types::{
     subnet::{
         self,
         rpc::{
+            context::Context,
             database::manager::{DatabaseManager, Manager},
             health::Checkable,
             snow::{
@@ -30,6 +31,7 @@ use avalanche_types::{
                     http_handler::{HttpHandler, LockOptions},
                     vm::{CommonVm, Connector},
                 },
+                validators::client::ValidatorStateClient,
             },
             snowman::block::{ChainVm, Getter, Parser},
         },
@@ -48,7 +50,7 @@ pub const PROPOSE_LIMIT_BYTES: usize = 1024 * 1024;
 /// Defined in a separate struct, for interior mutability in [`Vm`](Vm).
 /// To be protected with `Arc` and `RwLock`.
 pub struct State {
-    pub ctx: Option<subnet::rpc::context::Context>,
+    pub ctx: Option<Context<ValidatorStateClient>>,
     pub version: Version,
     pub genesis: Genesis,
 
@@ -212,10 +214,11 @@ where
     type AppSender = A;
     type ChainHandler = ChainHandler<ChainService<A>>;
     type StaticHandler = StaticHandler;
+    type ValidatorState = ValidatorStateClient;
 
     async fn initialize(
         &mut self,
-        ctx: Option<subnet::rpc::context::Context>,
+        ctx: Option<Context<Self::ValidatorState>>,
         db_manager: Self::DatabaseManager,
         genesis_bytes: &[u8],
         _upgrade_bytes: &[u8],


### PR DESCRIPTION
- updated e2e tests to run against AvalancheGo@1.10.0-fuji
- pump avalanche-types to support protocol version 25
- add support for validator state client as part of upcoming warp support.

Depends on #122 