### PR TITLE
0.0.14: add support for protocol version 26

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ See [`bin/timestampvm`](timestampvm/src/bin/timestampvm/main.rs) for plugin impl
 | v0.0.10 | v1.9.8, v1.9.9 |
 | v0.0.11,12 | v1.9.10 - v1.9.16 |
 | v0.0.13 | v1.10.0 |
+| v0.0.14 | v1.10.1+ |
 
 ## Example
 

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -11,13 +11,13 @@ homepage = "https://avax.network"
 [dependencies]
 
 [dev-dependencies]
-avalanche-installer = "0.0.58"
+avalanche-installer = "0.0.75"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.336", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.392", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
 env_logger = "0.10.0"
 log = "0.4.17"
 random-manager = "0.0.5"
-serde_json = "1.0.94" # https://github.com/serde-rs/json/releases
-tempfile = "3.4.0"
+serde_json = "1.0.96" # https://github.com/serde-rs/json/releases
+tempfile = "3.5.0"
 timestampvm = { path = "../../timestampvm" }
-tokio = { version = "1.27.0", features = [] } # https://github.com/tokio-rs/tokio/releases
+tokio = { version = "1.28.2", features = [] } # https://github.com/tokio-rs/tokio/releases

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use avalanche_network_runner_sdk::{BlockchainSpec, Client, GlobalConfig, StartRequest};
 use avalanche_types::{ids, jsonrpc::client::info as avalanche_sdk_info, subnet};
 
-const AVALANCHEGO_VERSION: &str = "v1.10.0-fuji";
+const AVALANCHEGO_VERSION: &str = "v1.10.2";
 
 #[tokio::test]
 async fn e2e() {

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "timestampvm"
-version = "0.0.13" # https://crates.io/crates/timestampvm
+version = "0.0.14" # https://crates.io/crates/timestampvm
 edition = "2021"
 rust-version = "1.68"
 publish = true
@@ -11,11 +11,11 @@ repository = "https://github.com/ava-labs/timestampvm-rs"
 readme = "../README.md"
 
 [dependencies]
-avalanche-types = { version = "0.0.336", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
-base64 = { version = "0.21.0" }
+avalanche-types = { version = "0.0.392", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
+base64 = { version = "0.21.2" }
 bytes = "1.4.0"
-chrono = "0.4.23"
-clap = { version = "4.1.8", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
+chrono = "0.4.25"
+clap = { version = "4.3.0", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 derivative = "2.2.0"
 env_logger = "0.10.0"
 http-manager = { version = "0.0.14" }
@@ -25,10 +25,10 @@ jsonrpc-derive = "18.0.0"
 log = "0.4.17"
 semver = "1.0.16"
 serde = { version = "1.0.152", features = ["derive"] }
-serde_json = "1.0.93" # https://github.com/serde-rs/json/releases
-serde_with = { version = "2.2.0", features = ["hex"] }
-tokio = { version = "1.27.0", features = ["fs", "rt-multi-thread"] }
-tonic = { version = "0.9.1", features = ["gzip"] }
+serde_json = "1.0.96" # https://github.com/serde-rs/json/releases
+serde_with = { version = "3.0.0", features = ["hex"] }
+tokio = { version = "1.28.2", features = ["fs", "rt-multi-thread"] }
+tonic = { version = "0.9.2", features = ["gzip"] }
 
 [dev-dependencies]
 random-manager = "0.0.5"


### PR DESCRIPTION
This PR bumps deps and adds support for AvalancheGo 1.10.1+ via protocol version 26.