### PR TITLE
0.0.17: bump deps

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -39,39 +39,39 @@ jobs:
         shell: bash
         run: scripts/tests.lint.sh
 
-  check_cargo_unused:
-    name: Check Cargo unused
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  # check_cargo_unused:
+  #   name: Check Cargo unused
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
 
-      # or use "abelfodil/protoc-action@v1"
-      # ref. https://github.com/hyperium/tonic/issues/1047#issuecomment-1222508191
-      - name: Install protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          version: "3.x"
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+  #     # or use "abelfodil/protoc-action@v1"
+  #     # ref. https://github.com/hyperium/tonic/issues/1047#issuecomment-1222508191
+  #     - name: Install protoc
+  #       uses: arduino/setup-protoc@v1
+  #       with:
+  #         version: "3.x"
+  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          profile: minimal
-          components: rustfmt, clippy
-          override: true
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: nightly
+  #         profile: minimal
+  #         components: rustfmt, clippy
+  #         override: true
 
-      - name: Check Rust version
-        run: rustc --version
+  #     - name: Check Rust version
+  #       run: rustc --version
 
-      - uses: Swatinem/rust-cache@v1
-        with:
-          cache-on-failure: true
+  #     - uses: Swatinem/rust-cache@v1
+  #       with:
+  #         cache-on-failure: true
 
-      - name: Check unused Cargo dependencies
-        shell: bash
-        run: scripts/tests.unused.sh
+  #     - name: Check unused Cargo dependencies
+  #       shell: bash
+  #       run: scripts/tests.unused.sh
 
   unit_tests:
     name: Unit tests

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -39,40 +39,6 @@ jobs:
         shell: bash
         run: scripts/tests.lint.sh
 
-  # check_cargo_unused:
-  #   name: Check Cargo unused
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     # or use "abelfodil/protoc-action@v1"
-  #     # ref. https://github.com/hyperium/tonic/issues/1047#issuecomment-1222508191
-  #     - name: Install protoc
-  #       uses: arduino/setup-protoc@v1
-  #       with:
-  #         version: "3.x"
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: nightly
-  #         profile: minimal
-  #         components: rustfmt, clippy
-  #         override: true
-
-  #     - name: Check Rust version
-  #       run: rustc --version
-
-  #     - uses: Swatinem/rust-cache@v1
-  #       with:
-  #         cache-on-failure: true
-
-  #     - name: Check unused Cargo dependencies
-  #       shell: bash
-  #       run: scripts/tests.unused.sh
-
   unit_tests:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -277,3 +243,37 @@ jobs:
           files: |
             ${{ steps.release_artifacts.outputs.file_name_timestampvm_rs }}
             ${{ steps.release_artifacts.outputs.file_name_timestampvm_rs_tar_gz }}
+
+ # check_cargo_unused:
+  #   name: Check Cargo unused
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     # or use "abelfodil/protoc-action@v1"
+  #     # ref. https://github.com/hyperium/tonic/issues/1047#issuecomment-1222508191
+  #     - name: Install protoc
+  #       uses: arduino/setup-protoc@v1
+  #       with:
+  #         version: "3.x"
+  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: nightly
+  #         profile: minimal
+  #         components: rustfmt, clippy
+  #         override: true
+
+  #     - name: Check Rust version
+  #       run: rustc --version
+
+  #     - uses: Swatinem/rust-cache@v1
+  #       with:
+  #         cache-on-failure: true
+
+  #     - name: Check unused Cargo dependencies
+  #       shell: bash
+  #       run: scripts/tests.unused.sh

--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -39,6 +39,40 @@ jobs:
         shell: bash
         run: scripts/tests.lint.sh
 
+  # check_cargo_unused:
+  #   name: Check Cargo unused
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+
+  #     # or use "abelfodil/protoc-action@v1"
+  #     # ref. https://github.com/hyperium/tonic/issues/1047#issuecomment-1222508191
+  #     - name: Install protoc
+  #       uses: arduino/setup-protoc@v1
+  #       with:
+  #         version: "3.x"
+  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+  #     - name: Install Rust
+  #       uses: actions-rs/toolchain@v1
+  #       with:
+  #         toolchain: nightly
+  #         profile: minimal
+  #         components: rustfmt, clippy
+  #         override: true
+
+  #     - name: Check Rust version
+  #       run: rustc --version
+
+  #     - uses: Swatinem/rust-cache@v1
+  #       with:
+  #         cache-on-failure: true
+
+  #     - name: Check unused Cargo dependencies
+  #       shell: bash
+  #       run: scripts/tests.unused.sh
+
   unit_tests:
     name: Unit tests
     runs-on: ubuntu-latest
@@ -112,7 +146,8 @@ jobs:
   release:
     name: Release ${{ matrix.job.target }} (${{ matrix.job.os }})
     runs-on: ${{ matrix.job.os }}
-    needs: [static_analysis, check_cargo_unused, unit_tests, e2e_tests]
+    #needs: [static_analysis, check_cargo_unused, unit_tests, e2e_tests]
+    needs: [static_analysis, unit_tests, e2e_tests]
     strategy:
       matrix:
         job:
@@ -243,37 +278,3 @@ jobs:
           files: |
             ${{ steps.release_artifacts.outputs.file_name_timestampvm_rs }}
             ${{ steps.release_artifacts.outputs.file_name_timestampvm_rs_tar_gz }}
-
- # check_cargo_unused:
-  #   name: Check Cargo unused
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - name: Checkout
-  #       uses: actions/checkout@v3
-
-  #     # or use "abelfodil/protoc-action@v1"
-  #     # ref. https://github.com/hyperium/tonic/issues/1047#issuecomment-1222508191
-  #     - name: Install protoc
-  #       uses: arduino/setup-protoc@v1
-  #       with:
-  #         version: "3.x"
-  #         repo-token: ${{ secrets.GITHUB_TOKEN }}
-
-  #     - name: Install Rust
-  #       uses: actions-rs/toolchain@v1
-  #       with:
-  #         toolchain: nightly
-  #         profile: minimal
-  #         components: rustfmt, clippy
-  #         override: true
-
-  #     - name: Check Rust version
-  #       run: rustc --version
-
-  #     - uses: Swatinem/rust-cache@v1
-  #       with:
-  #         cache-on-failure: true
-
-  #     - name: Check unused Cargo dependencies
-  #       shell: bash
-  #       run: scripts/tests.unused.sh

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See [`bin/timestampvm`](timestampvm/src/bin/timestampvm/main.rs) for plugin impl
 | v0.0.10 | v1.9.8, v1.9.9 |
 | v0.0.11,12 | v1.9.10 - v1.9.16 |
 | v0.0.13 | v1.10.0 |
-| v0.0.14,15 | v1.10.1+ |
+| v0.0.14..17 | v1.10.1+ |
 
 ## Example
 

--- a/tests/e2e/Cargo.toml
+++ b/tests/e2e/Cargo.toml
@@ -2,22 +2,22 @@
 name = "e2e"
 version = "0.0.0"
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 publish = false
-description = "Byzantine tests for Avalanche Go"
+description = "e2e tests for timestampvm"
 license = "BSD-3-Clause"
 homepage = "https://avax.network"
 
 [dependencies]
 
 [dev-dependencies]
-avalanche-installer = "0.0.76"
+avalanche-installer = "0.0.77"
 avalanche-network-runner-sdk = "0.3.0" # https://crates.io/crates/avalanche-network-runner-sdk
-avalanche-types = { version = "0.0.398", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.399", features = ["jsonrpc_client", "subnet"] } # https://crates.io/crates/avalanche-types
 env_logger = "0.10.0"
-log = "0.4.18"
+log = "0.4.19"
 random-manager = "0.0.5"
-serde_json = "1.0.96" # https://github.com/serde-rs/json/releases
+serde_json = "1.0.102" # https://github.com/serde-rs/json/releases
 tempfile = "3.6.0"
 timestampvm = { path = "../../timestampvm" }
-tokio = { version = "1.28.2", features = [] } # https://github.com/tokio-rs/tokio/releases
+tokio = { version = "1.29.1", features = [] } # https://github.com/tokio-rs/tokio/releases

--- a/tests/e2e/src/tests/mod.rs
+++ b/tests/e2e/src/tests/mod.rs
@@ -9,7 +9,7 @@ use std::{
 use avalanche_network_runner_sdk::{BlockchainSpec, Client, GlobalConfig, StartRequest};
 use avalanche_types::{ids, jsonrpc::client::info as avalanche_sdk_info, subnet};
 
-const AVALANCHEGO_VERSION: &str = "v1.10.2";
+const AVALANCHEGO_VERSION: &str = "v1.10.4";
 
 #[tokio::test]
 async fn e2e() {

--- a/timestampvm/Cargo.toml
+++ b/timestampvm/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "timestampvm"
-version = "0.0.16" # https://crates.io/crates/timestampvm
+version = "0.0.17" # https://crates.io/crates/timestampvm
 edition = "2021"
-rust-version = "1.69"
+rust-version = "1.70"
 publish = true
 description = "Timestamp VM in Rust"
 documentation = "https://docs.rs/timestampvm"
@@ -11,23 +11,23 @@ repository = "https://github.com/ava-labs/timestampvm-rs"
 readme = "../README.md"
 
 [dependencies]
-avalanche-types = { version = "0.0.398", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
+avalanche-types = { version = "0.0.399", features = ["subnet", "codec_base64"] } # https://crates.io/crates/avalanche-types
 base64 = { version = "0.21.2" }
 bytes = "1.4.0"
 chrono = "0.4.26"
-clap = { version = "4.3.2", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
+clap = { version = "4.3.11", features = ["cargo", "derive"] } # https://github.com/clap-rs/clap/releases
 derivative = "2.2.0"
 env_logger = "0.10.0"
 http-manager = { version = "0.0.14" }
 jsonrpc-core = "18.0.0"
 jsonrpc-core-client = { version = "18.0.0" }
 jsonrpc-derive = "18.0.0"
-log = "0.4.18"
+log = "0.4.19"
 semver = "1.0.17"
-serde = { version = "1.0.163", features = ["derive"] }
-serde_json = "1.0.96" # https://github.com/serde-rs/json/releases
+serde = { version = "1.0.171", features = ["derive"] }
+serde_json = "1.0.102" # https://github.com/serde-rs/json/releases
 serde_with = { version = "3.0.0", features = ["hex"] }
-tokio = { version = "1.28.2", features = ["fs", "rt-multi-thread"] }
+tokio = { version = "1.29.1", features = ["fs", "rt-multi-thread"] }
 tonic = { version = "0.9.2", features = ["gzip"] }
 
 [dev-dependencies]


### PR DESCRIPTION
This PR updates various dependencies and bumps the minimal rust version to `1.70` inline with avalanche-rust. This also brings the tested AvalancheGo version to `1.10.4`.

unused lint failure is transient dependency issue that has been resolved upstream[1] and should be fixed in the next dep bump. Disabling the check and adding an issue to track adding it back #190 .

[1]. https://github.com/dtolnay/proc-macro2/issues/398